### PR TITLE
hide weird imports in setup

### DIFF
--- a/modules/module1/module1-09-terminology.qmd
+++ b/modules/module1/module1-09-terminology.qmd
@@ -55,7 +55,6 @@ Let's make sure we understand all the components we use in a dataset for machine
 
 ```{pyodide}
 import pandas as pd
-from sklearn.dummy import DummyClassifier
 
 candybar_df = pd.read_csv('data/candybars.csv')
 candybar_df
@@ -70,6 +69,7 @@ candybar_df
 #| exercise: describing_a_dataset
 
 import pandas as pd
+from sklearn.dummy import DummyClassifier
 from src.utils import print_correct_msg
 
 candybar_df = pd.read_csv('data/candybars.csv')
@@ -167,7 +167,6 @@ For this dataframe the features are the columns `chocolate` to `multi` and the t
 
 ```{pyodide}
 import pandas as pd
-from sklearn.dummy import DummyClassifier
 
 candybar_df = pd.read_csv('data/candybars.csv')
 candybar_df
@@ -182,6 +181,7 @@ candybar_df
 #| exercise: separating_our_data_1
 
 import pandas as pd
+from sklearn.dummy import DummyClassifier
 from src.utils import print_correct_msg
 
 candybar_df = pd.read_csv('data/candybars.csv')


### PR DESCRIPTION
This is related to #45 . My hypothesis is that this issue is caused by importing sklearn packages in [src.utils](https://github.com/UBC-MDS/introduction-machine-learning/blob/main/src/utils.py#L7-L10). Since this issue is of low priority, I will just hide the sklearn imports in the setup cells, rather than going through the slides and adding the import statements.